### PR TITLE
Net::HTTP throws an error if send_image is passed an invalid transition type

### DIFF
--- a/lib/airplay/protocol/image.rb
+++ b/lib/airplay/protocol/image.rb
@@ -18,7 +18,8 @@ class Airplay::Protocol::Image
   end
 
   def transition_header(transition)
-    {"X-Apple-Transition" => transitions.fetch(transition, :none)}
+    # The fallback value should be whatever transitions[:none] is above
+    {"X-Apple-Transition" => transitions.fetch(transition, "None")}
   end
 
   def send(image, transition = :none)


### PR DESCRIPTION
Fallback to a string if passed an invalid transition type, otherwise Net::HTTP complains (roughly) "symbol has no method strip".
