### PR TITLE
Pull and interpret the DNS-SD text_record

### DIFF
--- a/lib/airplay.rb
+++ b/lib/airplay.rb
@@ -6,8 +6,9 @@ require 'uri'
 
 module Airplay end
 require 'airplay/server'
-require 'airplay/server/browser'
 require 'airplay/server/node'
+require 'airplay/server/browser'
+require 'airplay/server/features'
 
 require 'airplay/protocol'
 require 'airplay/protocol/image'

--- a/lib/airplay/server/browser.rb
+++ b/lib/airplay/server/browser.rb
@@ -14,15 +14,16 @@ module Airplay::Server::Browser
     timeout 3 do
       DNSSD.browse!(Airplay::Protocol::SEARCH) do |node|
         resolver = DNSSD::Service.new
-        target, port = nil
+        target, port, extra = nil
         resolver.resolve(node) do |resolved|
           port = resolved.port
           target = resolved.target
+          extra = resolved.text_record
           break unless resolved.flags.more_coming?
         end
         info = Socket.getaddrinfo(target, nil, Socket::AF_INET)
         ip = info[0][2]
-        @servers << Airplay::Server::Node.new(node.name, node.domain, ip, port)
+        @servers << Airplay::Server::Node.new(node.name, node.domain, ip, port, extra)
         break unless node.flags.more_coming?
       end
     end

--- a/lib/airplay/server/features.rb
+++ b/lib/airplay/server/features.rb
@@ -1,0 +1,29 @@
+class Airplay::Server::Features
+ attr_reader :Video,
+             :Photo,
+             :VideoFairPlay,
+             :VideoVolumeControl,
+             :VideoHTTPLiveStreams,
+             :Slideshow,
+             :Screen,
+             :ScreenRotate,
+             :Audio,
+             :AudioRedundant,
+             :FPSAPv2pt5_AES_GCM,
+             :PhotoCaching
+
+  def initialize(features)
+    @Video                = 0 == (features & ( 1 <<  0 ))
+    @Photo                = 0 == (features & ( 1 <<  1 ))
+    @VideoFairPlay        = 0 == (features & ( 1 <<  2 ))
+    @VideoVolumeControl   = 0 == (features & ( 1 <<  3 ))
+    @VideoHTTPLiveStreams = 0 == (features & ( 1 <<  4 ))
+    @Slideshow            = 0 == (features & ( 1 <<  5 ))
+    @Screen               = 0 == (features & ( 1 <<  7 ))
+    @ScreenRotate         = 0 == (features & ( 1 <<  8 ))
+    @Audio                = 0 == (features & ( 1 <<  9 ))
+    @AudioRedundant       = 0 == (features & ( 1 << 11 ))
+    @FPSAPv2pt5_AES_GCM   = 0 == (features & ( 1 << 12 ))
+    @PhotoCaching         = 0 == (features & ( 1 << 13 ))
+  end
+end

--- a/lib/airplay/server/node.rb
+++ b/lib/airplay/server/node.rb
@@ -1,7 +1,12 @@
 class Airplay::Server::Node
   attr_reader :name, :domain, :ip, :port
+  attr_reader :features, :deviceid, :model, :srcvers
 
-  def initialize(name, domain, ip, port)
+  def initialize(name, domain, ip, port, info)
     @name, @domain, @ip, @port = name, domain, ip, port
+    @features = Airplay::Server::Features.new info.fetch('features', 0).hex
+    @deviceid = info.fetch('deviceid')
+    @srcvers  = info.fetch('srcvers')
+    @model    = info.fetch('model')
   end
 end


### PR DESCRIPTION
This grabs the text_record field from DNS-SD. By way of example:

``` ruby
require 'airplay'
a = Airplay::Client.new
p a.active.inspect

"#<Airplay::Server::Node:0x007fcae303ebd8
 @port=7000,
 @ip=\"192.168.1.25\",
 @domain=\"local.\",
 @name=\"TV\",
 @deviceid=\"3D:07:54:18:40:DE\",
 @srcvers=\"130.14\",
 @model=\"AppleTV2,1\"
 @features=#<Airplay::Server::Features:0x007fcae303eac0
  @Video=false,
  @Photo=false,
  @VideoFairPlay=false,
  @VideoVolumeControl=false,
  @VideoHTTPLiveStreams=false,
  @Slideshow=false,
  @Screen=false,
  @ScreenRotate=false,
  @Audio=true,
  @AudioRedundant=false,
  @FPSAPv2pt5_AES_GCM=true,
  @PhotoCaching=false>>"
```

I am using field names from http://nto.github.com/AirPlay.html#servicediscovery-airplayservice
