### PR TITLE
Fix usage of Airplay::Server::Node.new in test/helper.rb

### DIFF
--- a/lib/airplay/server/node.rb
+++ b/lib/airplay/server/node.rb
@@ -4,9 +4,11 @@ class Airplay::Server::Node
 
   def initialize(name, domain, ip, port, info)
     @name, @domain, @ip, @port = name, domain, ip, port
-    @features = Airplay::Server::Features.new info.fetch('features', '0').hex
-    @deviceid = info.fetch('deviceid', nil)
-    @srcvers  = info.fetch('srcvers', nil)
-    @model    = info.fetch('model', nil)
+    if info
+      @features = Airplay::Server::Features.new info.fetch('features', '0').hex
+      @deviceid = info.fetch('deviceid', nil)
+      @srcvers  = info.fetch('srcvers', nil)
+      @model    = info.fetch('model', nil)
+    end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ module MockedBrowser
   attr_reader :servers
 
   def self.browse
-    @servers = [Airplay::Server::Node.new("Mock TV", ".local", "mocktv.local", 7000)]
+    @servers = [Airplay::Server::Node.new("Mock TV", ".local", "mocktv.local", 7000, nil)]
   end
 
   def self.find_by_name(name)


### PR DESCRIPTION
Tests weren't running since e41c91ce26332b5512d0806155c66a5098892332,
although for some reason rake was still returning exit code 0 and
thus Travis never detected the problem.
