### PR TITLE
Fixed bug where infinite streams would cause a crash

### DIFF
--- a/lib/airplay/player/playback_info.rb
+++ b/lib/airplay/player/playback_info.rb
@@ -10,7 +10,7 @@ module Airplay
       end
 
       def has_duration?
-        duration && duration != 0.0
+        !duration.to_f.zero?
       end
 
       def position


### PR DESCRIPTION
A friend of mine and I were using this and he noted that it crashed on infinite streams so I guarded against duration being 0.0.
