### PR TITLE
Add exception class Airplay::Error::UnsupportedType

### DIFF
--- a/lib/airplay.rb
+++ b/lib/airplay.rb
@@ -7,6 +7,10 @@ require "airplay/version"
 # Public: Airplay core module
 #
 module Airplay
+  # Airplay will throw exceptions with these types
+  class Error < StandardError; end
+  class Error::UnsupportedType < Error; end
+
   class << self
     # Public: General configuration
     #

--- a/lib/airplay/viewer.rb
+++ b/lib/airplay/viewer.rb
@@ -63,7 +63,7 @@ module Airplay
       when is_url?(media_or_io)    then open(media_or_io).read
       when is_string?(media_or_io) then media_or_io
       when is_io?(media_or_io)     then media_or_io.read
-      else raise TypeError.new("Unsupported type")
+      else raise Airplay::Error::UnsupportedType
       end
     end
 

--- a/test/integration/view_images_test.rb
+++ b/test/integration/view_images_test.rb
@@ -34,6 +34,6 @@ describe "Sending images to a device" do
 
   context "sending an unsupported type" do
     When(:view) { device.view(42) }
-    Then { view == Failure(TypeError) }
+    Then { view == Failure(Airplay::Error::UnsupportedType) }
   end
 end


### PR DESCRIPTION
This replaces use of TypeError with an exception under the Airplay namespace.

I don't think this was the right way to use TypeError, because in several cases the target variable is a String with different encodings or contents. Typically a TypeError is raised in case of using e.g. a String when an Integer is expected.

That said... the original code is growing on me. One could pass an IO object and that would work, whereas an Integer would fail, and so TypeError makes sense.
