### PR TITLE
fix NoMethodError: undefined method `body' for #<Airplay::Connection::Re...

### DIFF
--- a/lib/airplay/player.rb
+++ b/lib/airplay/player.rb
@@ -130,7 +130,7 @@ module Airplay
     #
     def scrub
       return unless playing?
-      response = connection.get("/scrub")
+      response = connection.get("/scrub").response
       parts = response.body.split("\n")
       Hash[parts.collect { |v| v.split(": ") }]
     end


### PR DESCRIPTION
...sponse:0x007f800520eb58>

Player#scrub raised NoMethodError: undefined method `body' for #Airplay::Connection::Response:0x007f800520eb58
