### PR TITLE
Don't fail if there is a dir inside the folder viewed

### DIFF
--- a/lib/airplay/viewer.rb
+++ b/lib/airplay/viewer.rb
@@ -89,7 +89,7 @@ module Airplay
     #
     def is_file?(string)
       return false if string.is_a?(StringIO)
-      File.exists?(File.expand_path(string))
+      !File.directory?(string) && File.exists?(File.expand_path(string))
     rescue
       false
     end


### PR DESCRIPTION
The `air view [image folder]` fails if there is a folder inside besides other files.
This fix prevents that error from happening.
