### PR TITLE
Fix --device logic for view action

### DIFF
--- a/bin/air
+++ b/bin/air
@@ -31,7 +31,7 @@ begin
 
     "view" => lambda { |file|
       options = {
-        device: @device || @url ? false : Airplay.devices.first,
+        device: @url ? false : @device || Airplay.devices.first,
         interactive: @interactive || false,
         password: @password || false,
         url: @url || false,


### PR DESCRIPTION
The current implementation basically always sets device to false when
a device is explicitly set.